### PR TITLE
Compressor cache

### DIFF
--- a/libdeflate.c
+++ b/libdeflate.c
@@ -68,7 +68,14 @@ typedef size_t (*php_libdeflate_compress_func)(struct libdeflate_compressor*, co
 
 static inline zend_string* php_libdeflate_compress(zend_string *data, zend_long level, php_libdeflate_compress_bound_func compressBoundFunc, php_libdeflate_compress_func compressFunc) {
 	if (level < 0 || level > MAX_COMPRESSION_LEVEL) {
-		zend_value_error("Invalid compression level: %zi (accepted levels: %u...%u)", level, 0, MAX_COMPRESSION_LEVEL);
+		zend_throw_exception_ex(
+			spl_ce_InvalidArgumentException,
+			0,
+			"Invalid compression level: %zi (accepted levels: %u...%u)",
+			level,
+			0,
+			MAX_COMPRESSION_LEVEL
+		);
 		return NULL;
 	}
 

--- a/libdeflate.c
+++ b/libdeflate.c
@@ -22,10 +22,6 @@ ZEND_END_MODULE_GLOBALS(libdeflate);
 
 ZEND_DECLARE_MODULE_GLOBALS(libdeflate);
 
-PHP_MINIT_FUNCTION(libdeflate) {
-	libdeflate_set_memory_allocator(_emalloc, _efree);
-}
-
 /* {{{ PHP_RINIT_FUNCTION
  */
 PHP_RINIT_FUNCTION(libdeflate)
@@ -141,7 +137,7 @@ zend_module_entry libdeflate_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"libdeflate",
 	libdeflate_functions,
-	PHP_MINIT(libdeflate),
+	NULL,
 	NULL, /* PHP_MSHUTDOWN */
 	PHP_RINIT(libdeflate),
 	PHP_RSHUTDOWN(libdeflate),

--- a/libdeflate.c
+++ b/libdeflate.c
@@ -12,7 +12,7 @@
 
 
 #define MAX_COMPRESSION_LEVEL 12
-#define COMPRESSOR_CACHE_SIZE MAX_COMPRESSION_LEVEL + 1 //extra slot for level 0
+#define COMPRESSOR_CACHE_SIZE (MAX_COMPRESSION_LEVEL + 1) //extra slot for level 0
 
 ZEND_BEGIN_MODULE_GLOBALS(libdeflate)
 	struct libdeflate_compressor* compressor_cache[COMPRESSOR_CACHE_SIZE];
@@ -30,7 +30,7 @@ PHP_RINIT_FUNCTION(libdeflate)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 
-	memset(LIBDEFLATE_G(compressor_cache), 0, sizeof(LIBDEFLATE_G(compressor_cache)));
+	memset(LIBDEFLATE_G(compressor_cache), 0, sizeof(struct libdeflate_compressor*) * COMPRESSOR_CACHE_SIZE);
 	return SUCCESS;
 }
 /* }}} */
@@ -38,11 +38,13 @@ PHP_RINIT_FUNCTION(libdeflate)
 /* {{{ */
 PHP_RSHUTDOWN_FUNCTION(libdeflate) {
 	for (int i = 0; i < COMPRESSOR_CACHE_SIZE; i++) {
-		struct libdeflate_compressor* compressor = LIBDEFLATE_G(compressor_cache)[0];
+		struct libdeflate_compressor* compressor = LIBDEFLATE_G(compressor_cache)[i];
 		if (compressor != NULL) {
 			libdeflate_free_compressor(compressor);
 		}
 	}
+
+	return SUCCESS;
 } /* }}} */
 
 /* {{{ PHP_MINFO_FUNCTION
@@ -144,6 +146,8 @@ zend_module_entry libdeflate_module_entry = {
 	PHP_MINFO(libdeflate),
 	PHP_LIBDEFLATE_VERSION,
 	PHP_MODULE_GLOBALS(libdeflate),
+	NULL,
+	NULL,
 	NULL,
 	STANDARD_MODULE_PROPERTIES_EX
 };

--- a/libdeflate.c
+++ b/libdeflate.c
@@ -10,6 +10,22 @@
 #include "php_libdeflate.h"
 #include "libdeflate.h"
 
+
+#define MAX_COMPRESSION_LEVEL 12
+#define COMPRESSOR_CACHE_SIZE MAX_COMPRESSION_LEVEL + 1 //extra slot for level 0
+
+ZEND_BEGIN_MODULE_GLOBALS(libdeflate)
+	struct libdeflate_compressor* compressor_cache[COMPRESSOR_CACHE_SIZE];
+ZEND_END_MODULE_GLOBALS(libdeflate);
+
+#define LIBDEFLATE_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(libdeflate, v)
+
+ZEND_DECLARE_MODULE_GLOBALS(libdeflate);
+
+PHP_MINIT_FUNCTION(libdeflate) {
+	libdeflate_set_memory_allocator(_emalloc, _efree);
+}
+
 /* {{{ PHP_RINIT_FUNCTION
  */
 PHP_RINIT_FUNCTION(libdeflate)
@@ -18,9 +34,20 @@ PHP_RINIT_FUNCTION(libdeflate)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 
+	memset(LIBDEFLATE_G(compressor_cache), 0, sizeof(LIBDEFLATE_G(compressor_cache)));
 	return SUCCESS;
 }
 /* }}} */
+
+/* {{{ */
+PHP_RSHUTDOWN_FUNCTION(libdeflate) {
+	for (int i = 0; i < COMPRESSOR_CACHE_SIZE; i++) {
+		struct libdeflate_compressor* compressor = LIBDEFLATE_G(compressor_cache)[0];
+		if (compressor != NULL) {
+			libdeflate_free_compressor(compressor);
+		}
+	}
+} /* }}} */
 
 /* {{{ PHP_MINFO_FUNCTION
  */
@@ -42,10 +69,19 @@ typedef size_t (*php_libdeflate_compress_bound_func)(struct libdeflate_compresso
 typedef size_t (*php_libdeflate_compress_func)(struct libdeflate_compressor*, const void*, size_t, void*, size_t);
 
 static inline zend_string* php_libdeflate_compress(zend_string *data, zend_long level, php_libdeflate_compress_bound_func compressBoundFunc, php_libdeflate_compress_func compressFunc) {
-	struct libdeflate_compressor* compressor = libdeflate_alloc_compressor(level);
-	if (compressor == NULL) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unable to allocate libdeflate compressor");
+	if (level < 0 || level > MAX_COMPRESSION_LEVEL) {
+		zend_value_error("Invalid compression level: %zi (accepted levels: %u...%u)", level, 0, MAX_COMPRESSION_LEVEL);
 		return NULL;
+	}
+
+	struct libdeflate_compressor* compressor = LIBDEFLATE_G(compressor_cache)[level];
+	if (compressor == NULL) {
+		compressor = libdeflate_alloc_compressor(level);
+		if (compressor == NULL) {
+			zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unable to allocate libdeflate compressor (this is a bug)");
+			return NULL;
+		}
+		LIBDEFLATE_G(compressor_cache)[level] = compressor;
 	}
 
 	size_t compressBound = compressBoundFunc(compressor, ZSTR_LEN(data));
@@ -59,7 +95,6 @@ static inline zend_string* php_libdeflate_compress(zend_string *data, zend_long 
 
 	zend_string* result = zend_string_init(output, actualSize, 0);
 	efree(output);
-	libdeflate_free_compressor(compressor);
 	return result;
 }
 
@@ -106,13 +141,15 @@ zend_module_entry libdeflate_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"libdeflate",
 	libdeflate_functions,
-	NULL, /* PHP_MINIT */
+	PHP_MINIT(libdeflate),
 	NULL, /* PHP_MSHUTDOWN */
-	PHP_RINIT(libdeflate), /* PHP_RINIT */
-	NULL, /* PHP_RSHUTDOWN */
+	PHP_RINIT(libdeflate),
+	PHP_RSHUTDOWN(libdeflate),
 	PHP_MINFO(libdeflate),
 	PHP_LIBDEFLATE_VERSION,
-	STANDARD_MODULE_PROPERTIES
+	PHP_MODULE_GLOBALS(libdeflate),
+	NULL,
+	STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */
 

--- a/tests/invalid-compression-level.phpt
+++ b/tests/invalid-compression-level.phpt
@@ -7,13 +7,13 @@ Test that libdeflate_deflate_compress() doesn't segfault when given an invalid c
 
 try{
 	libdeflate_deflate_compress("aaaaaa", -1);
-}catch(\RuntimeException $e){
+}catch(\InvalidArgumentException $e){
 	var_dump("ok");
 }
 
 try{
 	libdeflate_deflate_compress("aaaaaa", 13);
-}catch(\RuntimeException $e){
+}catch(\InvalidArgumentException $e){
 	var_dump("ok");
 }
 ?>

--- a/tests/normal-compression.phpt
+++ b/tests/normal-compression.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test that compression works normally
+--FILE--
+<?php
+
+$buffer = str_repeat("abcdefghijklmnopqrstuvwxyz", 1000);
+
+foreach([
+    'libdeflate_deflate_compress',
+    'libdeflate_zlib_compress',
+    'libdeflate_gzip_compress'
+] as $function){
+    $compressedBuffers = [];
+    for($i = 1; $i <= 10; $i++){
+        for($level = 0; $level <= 12; $level++){
+            $compressed = libdeflate_deflate_compress($buffer, $level);
+
+            if(isset($compressedBuffers[$level]) && $compressedBuffers[$level] !== $compressed){
+                throw new \Error("Different output for compression on level $level on run $i");
+            }
+            $compressedBuffers[$level] = $compressed;
+        }
+    }
+
+    var_dump(count($compressedBuffers));
+    foreach($compressedBuffers as $level => $compressed){
+        if($level === 0){
+            if(strpos($compressed, $buffer) === false){
+                var_dump($compressed);
+                throw new \Error("Output for level 0 doesn't contain recognizable data");
+            }
+        }elseif(strlen($compressed) >= strlen($buffer)){
+            //this string is definitely compressible
+            throw new \Error("Level $level didn't compress anything");
+        }
+    }
+}
+?>
+--EXPECT--
+int(13)
+int(13)
+int(13)


### PR DESCRIPTION
As it turns out, allocating compressors is surprisingly expensive, and it makes up a significant portion of the runtime at lower compression levels.

This PR caches allocated compressors in request globals, which allows them to be reused by the thread they were allocated in, reducing the amount of work required.